### PR TITLE
Fix issue #9 - allow overriding jsdoc config file from sphinx conf.py…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ Setup
    of your JS source tree is at that path, relative to conf.py itself. The
    default is ``../``, which works well when there is a ``docs`` folder at the
    root of your project.
+6. Optionally, add ``js_config_path = '../conf.json'`` to a ``jsdoc``
+   configuration file. If not specified, then no config file will be used.
 
 Use
 ===

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -24,6 +24,7 @@ def setup(app):
     # TODO: We could add a js:module with app.add_directive_to_domain().
 
     app.add_config_value('js_source_path', '../', 'env')
+    app.add_config_value('js_config_path', None, 'env')
 
 
 def read_all_docs(app, env, doc_names):

--- a/sphinx_js/jsdoc.py
+++ b/sphinx_js/jsdoc.py
@@ -5,7 +5,10 @@ from subprocess import check_output
 def run_jsdoc(app):
     """Run JSDoc across a whole codebase, and squirrel away its results."""
     # JSDoc defaults to utf8-encoded output.
-    doclets = loads(check_output(['jsdoc', app.config.js_source_path, '-X']).decode('utf8'))
+    jsdoc_command = ['jsdoc', app.config.js_source_path, '-X']
+    if app.config.js_config_path:
+        jsdoc_command.extend(['-c', app.config.js_config_path])
+    doclets = loads(check_output(jsdoc_command).decode('utf8'))
     app._sphinxjs_jsdoc_output = dict((d['longname'], d) for d in doclets
                                       if d.get('comment')
                                       and not d.get('undocumented'))


### PR DESCRIPTION
… via js_config_path.