### PR TITLE
[not ready for review] Tests for object initializer and private forward.

### DIFF
--- a/tests/source/code.js
+++ b/tests/source/code.js
@@ -90,3 +90,111 @@ const NoParamnames = {};
 
 /** Thing to be shadowed in more_code.js */
 function shadow() {}
+
+/**
+ * Object initializer "class" definition in literal notation.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer
+ * @class
+ */
+var ObjectLiteralClass = {
+    /**
+     * Foos the bars.
+     * @param {string} bar - the Bar to Foo.
+     * @returns {string} - Returns the Foo'd Bar.
+     */
+    foo(bar) {
+        return bar;
+    }
+}
+
+/**
+ * Private class renamed as public class, using the jsdoc lends tag.
+ *
+ * A common pattern in some codebases is to have a public class which
+ * forwards to a private class, where the jsdoc annotations live.
+ *
+ * @lends PublicClass
+ */
+class PrivateClass {
+    /**
+     * This is the method we want to appear on the public API.
+     * @param {string} foo - We want the foo.
+     */
+    public(foo) {
+        return foo;
+    }
+
+    /**
+     * This is a private method which should *not* appear on the public API.
+     * @param {string} foo - Gotta have that foo.
+     * @private
+     */
+    private(foo) {
+        return foo
+    }
+}
+
+/**
+ * This is the public API. All methods forward to PrivateClass.
+ */
+class PublicClass {
+    constructor() {
+        this._privateClass = new PrivateClass();
+    }
+
+    /**
+     * This should *not* appear in the documentation.
+     *
+     * @param {string} foo - You don't want this foo.
+     * @private
+     */
+    public(foo) {
+        return this._privateClass(foo);
+    }
+}
+
+/**
+ * Private class renamed as public class, using the jsdoc lends tag.
+ * Same as above but using object initializer written in literal object
+ * notation.
+ *
+ * A common pattern in some codebases is to have a public class which
+ * forwards to a private class, where the jsdoc annotations live.
+ *
+ * @lends PublicObjectLiteral
+ */
+var PrivateObjectLiteral = {
+    /**
+     * This is the method we want to appear on the public API.
+     * @param {string} foo - We want the foo.
+     */
+    public(foo) {
+        return foo;
+    },
+
+    /**
+     * This is a private method which should *not* appear on the public API.
+     * @param {string} foo - Gotta have that foo.
+     * @private
+     */
+    private(foo) {
+        return foo
+    }
+}
+
+/**
+ * This is the public API. All methods forward to PrivateClass.
+ */
+var PublicObjectLiteral = {
+    _privateClass: new PrivateClass(),
+
+    /**
+     * This should *not* appear in the documentation.
+     *
+     * @param {string} foo - You don't want this foo.
+     * @private
+     */
+    public(foo) {
+        return this._privateClass(foo);
+    }
+}

--- a/tests/source/docs/autoclass_object_literal.rst
+++ b/tests/source/docs/autoclass_object_literal.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ObjectLiteralClass
+   :members:

--- a/tests/source/docs/autoclass_object_literal_private_forwarding.rst
+++ b/tests/source/docs/autoclass_object_literal_private_forwarding.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: PublicObjectLiteral
+   :members:

--- a/tests/source/docs/autoclass_private_forwarding.rst
+++ b/tests/source/docs/autoclass_private_forwarding.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: PublicClass
+   :members:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -122,6 +122,24 @@ class Tests(TestCase):
             'avoid_shadowing',
             'more_code.shadow()\n\n   Another thing named shadow, to threaten to shadow the one in\n   code.js\n')
 
+    def test_object_literal(self):
+        """Make sure object initializer classes can be documented."""
+        self._file_contents_eq(
+            'autoclass_object_literal',
+            'class ObjectLiteralClass()\n\n   Object initializer \u201cclass\u201d definition in literal notation.\n\n   ObjectLiteralClass.foo()\n\n      Foos the bars.\n\n      Arguments:\n         * **bar** (*string*) \u2013 the Bar to Foo.\n\n      Returns:\n         **string** \u2013 - Returns the Foo\u2019d Bar.\n')
+
+    def test_private_forwarding(self):
+        """Make sure public classes that forward to private classes can be documented."""
+        self._file_contents_eq(
+            'autoclass_private_forwarding',
+            'class PublicClass()\n\n   This is the public API. All methods forward to PrivateClass.\n\n   PublicClass.public(foo)\n\n      This is the method we want to appear on the public API.\n\n      Arguments:\n         * **foo** (*string*) \u2013 We want the foo.\n')
+
+    def test_autoclass_object_literal_private_forwarding(self):
+        """Make sure public object initalizers that forward to private object initalizers can be documented."""
+        self._file_contents_eq(
+            'autoclass_object_literal_private_forwarding',
+            'class PublicObjectLiteral()\n\n   This is the public API. All methods forward to PrivateClass.\n\n   PublicObjectLiteral.public()\n\n      This is the method we want to appear on the public API.\n\n      Arguments:\n         * **foo** (*string*) \u2013 We want the foo.\n')
+
     @classmethod
     def teardown_class(cls):
         rmtree(join(cls.docs_dir, '_build'))


### PR DESCRIPTION
Some code bases use "object initalizer" classes. A common approach
is to document the class in literal notation.
See
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer

Also - some code bases use public classes which have public methods
that forward to a private class. The private class generally has the
jsdoc annotations. In this case, the documentation should use the
public class as the name, but take the documentation on the methods
in the private class.