### PR TITLE
Add the ability to have multiple folders in js_source_path.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,18 @@ Saving Keystrokes By Setting The Primary Domain
 
 To save some keystrokes, you can set ``primary_domain = 'js'`` in conf.py and then say (for example) ``autofunction`` rather than ``js:autofunction``.
 
+Configuration Reference
+-----------------------
+
+``js_source_path``
+  A list of directories to scan (non-recursively) for JS files. Can be a string instead if there is only one. If there is more than one, ``root_for_relative_js_paths`` must be specified as well.
+
+``jsdoc_config_path``
+  A conf.py-relative path to a jsdoc config file, which is useful if you want to specify your own jsdoc options, like recursion and custom filename matching.
+
+``root_for_relative_js_paths``
+  The directory relative to which relative pathnames are resolved. Defaults to ``js_source_path`` if it is only one item.
+
 Example
 =======
 
@@ -247,6 +259,7 @@ Version History
 
 2.1
   * Aggregate PathTaken errors, and report them all at once. This means you don't have to run JSDoc repeatedly while cleaning up large projects.
+  * Allow multiple folders in ``js_source_path``. This is useful for gradually migrating large projects, one folder at a time, to jsdoc. Introduce ``root_for_relative_js_paths`` to keep relative paths unambiguous in the face of multiple source paths.
 
 2.0.1
   * Fix spurious syntax errors while loading large JSDoc output by writing it to a temp file first. (jhkennedy)

--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -26,6 +26,12 @@ def setup(app):
     app.add_config_value('js_source_path', '../', 'env')
     app.add_config_value('jsdoc_config_path', None, 'env')
 
+    # We could use a callable as the "default" param here, but then we would
+    # have had to duplicate or build framework around the logic that promotes
+    # js_source_path to a list and calls abspath() on it. It's simpler this way
+    # until we need to access js_source_path from more than one place.
+    app.add_config_value('root_for_relative_js_paths', None, 'env')
+
 
 def read_all_docs(app, env, doc_names):
     """Add all found docs to the to-be-read list, because we have no way of

--- a/tests/test_jsdoc.py
+++ b/tests/test_jsdoc.py
@@ -1,6 +1,9 @@
-from nose.tools import eq_
+from os.path import abspath
 
-from sphinx_js.jsdoc import doclet_full_path
+from nose.tools import assert_raises, eq_
+from sphinx.errors import SphinxError
+
+from sphinx_js.jsdoc import doclet_full_path, root_or_fallback
 
 
 def test_doclet_full_path():
@@ -13,3 +16,12 @@ def test_doclet_full_path():
     }
     eq_(doclet_full_path(doclet, '/boogie/smoo/Checkouts'),
         ['./', 'fathom/', 'utils.', 'best#', 'thing~', 'yeah'])
+
+
+def test_relative_path_root():
+    """Make sure the computation of the root path for relative JS entity
+    pathnames is right."""
+    # Fall back to the only source path if not specified.
+    eq_(root_or_fallback(None, ['a']), 'a')
+    assert_raises(SphinxError, root_or_fallback, None, ['a', 'b'])
+    eq_(root_or_fallback('smoo', ['a']), abspath('smoo'))


### PR DESCRIPTION
This is useful for slowly making the jsdoc cleanly parse in large projects like Firefox.

This still needs tests.