### PR TITLE
Handle encoding of temporary file

### DIFF
--- a/sphinx_js/jsdoc.py
+++ b/sphinx_js/jsdoc.py
@@ -3,6 +3,7 @@ from json import load
 from os.path import abspath, relpath, sep
 from subprocess import PIPE, Popen
 from tempfile import TemporaryFile
+from codecs import getwriter
 
 from six import iterkeys, python_2_unicode_compatible
 
@@ -21,7 +22,7 @@ def run_jsdoc(app):
         jsdoc_command.extend(['-c', app.config.jsdoc_config_path])
 
     # Use a temporary file to handle large output volume
-    with TemporaryFile() as temp:
+    with getwriter('utf-8')(TemporaryFile(mode='w+')) as temp:
         p = Popen(jsdoc_command, stdout=temp, stderr=PIPE)
         p.wait()
         # Once output is finished, move back to beginning of file and load it:


### PR DESCRIPTION
A temporary file is used to store the output of the `jsdoc` command in
case of a large output volume, but for some version of python and some
machines, the file encoding wasn't handled properly.

This commit explicitly opens a text-mode temporary file with `utf-8`
encoding which should eliminate this problem across pythons/platforms.

fixes erikrose/sphinx-js#20