### PR TITLE
Add support to @typedef and @callback

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -118,6 +118,7 @@ class JsRenderer(object):
 
         """
         FIELD_TYPES = OrderedDict([('params', _params_formatter),
+                                   ('properties', _params_formatter),
                                    ('exceptions', _exceptions_formatter),
                                    ('returns', _returns_formatter)])
         for field_name, callback in iteritems(FIELD_TYPES):
@@ -168,7 +169,7 @@ class AutoClassRenderer(JsRenderer):
 
         """
         def rst_for(doclet):
-            renderer = (AutoFunctionRenderer if doclet.get('kind') == 'function'
+            renderer = (AutoFunctionRenderer if doclet.get('kind') in ['function', 'typedef']
                         else AutoAttributeRenderer)
             # Pass a dummy arg list with no formal param list so
             # _formal_params() won't find an explicit param list in there and

--- a/tests/source/code.js
+++ b/tests/source/code.js
@@ -90,3 +90,15 @@ const NoParamnames = {};
 
 /** Thing to be shadowed in more_code.js */
 function shadow() {}
+
+/**
+ * @typedef {Object} TypeDefinition
+ * @property {Number} width - width in pixels
+ */
+
+
+/**
+ * Some global callback
+ * @callback requestCallback
+ * @param {number} responseCode
+ */

--- a/tests/source/docs/autofunction_callback.rst
+++ b/tests/source/docs/autofunction_callback.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: requestCallback

--- a/tests/source/docs/autofunction_typedef.rst
+++ b/tests/source/docs/autofunction_typedef.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: TypeDefinition

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -62,13 +62,13 @@ class Tests(TestCase):
         """Make that typedef works."""
         self._file_contents_eq(
             'autofunction_typedef',
-            'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) – width in pixels\n')
+            u'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) – width in pixels\n')
 
     def test_autofunction_callback(self):
         """Make that callback works."""
         self._file_contents_eq(
             'autofunction_callback',
-            'requestCallback()\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) –\n')
+            u'requestCallback()\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) –\n')
 
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -58,6 +58,18 @@ class Tests(TestCase):
             'autofunction_long',
             'ContainingClass.someMethod(hi)\n\n   Here.\n')
 
+    def test_autofunction_typedef(self):
+        """Make that typedef works."""
+        self._file_contents_eq(
+            'autofunction_typedef',
+            'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) – width in pixels\n')
+
+    def test_autofunction_callback(self):
+        """Make that callback works."""
+        self._file_contents_eq(
+            'autofunction_callback',
+            'requestCallback()\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) –\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""


### PR DESCRIPTION
Hi @erikrose,

Thank you for this sphinx extension. I have a tiny PR (only two lines changed) which makes a huge difference to real jsdoc documentation.

@[typedef](http://usejsdoc.org/tags-typedef.html) and @[callback](http://usejsdoc.org/tags-callback.html) are of kind 'typedef'. If we treat the `typedef` kind the same way as a `function` when parsing classes, we will get a nice documentation for **callbacks** (slightly changing just one line of `AutoClassRenderer.rst_for`!).

Here is an example - following declaration:

```js
    /**
     * Callback called after the plot is scrolled horizontally
     *
     * @callback position_callback
     * @memberOf NeedlePlot
     * @param {number} new_position - position (in aminoacids) of the first visible aminoacid in the plot
     * @param {boolean} stop_callback
     */
```
is currently shown as:
![screenshot from 2017-09-26 21-06-50](https://user-images.githubusercontent.com/5832902/30884353-cafda804-a2fe-11e7-81b4-2a1a83d91e79.png)

and after the change it will become:
![screenshot from 2017-09-26 21-07-11](https://user-images.githubusercontent.com/5832902/30884354-cf52afa8-a2fe-11e7-987c-acfe535ff4af.png)

The normal use of `typedef` can be accompanied with a lot of `properties` which could be really treated the same way as `params`. Please see the following example:

```js
    /**
     * @typedef {Object} Config
     * @memberOf NeedlePlot
     * @property {HTMLElement} element - an HTML wrapper in which the needleplot will be inserted
     * @property {Object} data - mutation and site data
     * @property {number} [width] - width in pixels
     * @property {number} [height] - height in pixels (or null if should be determined from ratio)
     * @property {NeedlePlot.Tooltip} [needle_tooltip]
     * @property {NeedlePlot.position_callback} [position_callback] - will be called on move event
     */
```

is now rendered as (no properties visible at all!):
![screenshot from 2017-09-26 21-12-14](https://user-images.githubusercontent.com/5832902/30884570-adddae12-a2ff-11e7-9ef0-1b22a1ba6875.png)

but after adding field type `properties` with the save formatter as `params` it becomes:

![screenshot from 2017-09-26 21-20-56](https://user-images.githubusercontent.com/5832902/30884852-aae2d3a8-a300-11e7-80e6-ccad5db0510c.png)

I think that adding custom formatter for properties which would print out "Properties" instead of "Attributes" would be a better solution for the future but I feel a little bit uncomfortable editing larger chunks of the code now (it is difficult to understand some constructs with so little documentation). Also I would like to hear from you - if you are wiling to accept this patch or similar changes - before digging deeper in the code.