### PR TITLE
Add "*" (and the rest) option to autoclass :members:.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,11 @@ Or explicitly list the members you want. We will respect your ordering. ::
     .. js:autoclass:: SomeEs6Class
        :members: Qux, qum
 
+When explicitly listing members, you can include ``*`` to include all unmentioned members. This is useful to have control over ordering of some elements, without having to include an exhaustive list. ::
+
+    .. js:autoclass:: SomeEs6Class
+       :members: importMethod, *, uncommonlyUsedMethod
+
 Finally, if you want full control, pull your class members in one at a time by embedding ``js:autofunction`` or ``js:autoattribute``::
 
     .. js:autoclass:: SomeEs6Class

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -194,6 +194,15 @@ class AutoClassRenderer(JsRenderer):
                 # Specifying none means listing all.
                 return sorted(doclets, key=lambda d: d['name'])
             included_set = set(include)
+
+            # If the special name * is included in the list, include
+            # all other doclets, in sorted order.
+            if '*' in included_set:
+                star_index = include.index('*')
+                not_included = sorted(d['name'] for d in doclets if d['name'] not in included_set)
+                include = include[:star_index] + not_included + include[star_index + 1:]
+                included_set.update(not_included)
+
             # Even if there are 2 doclets with the same short name (e.g. a
             # static member and an instance one), keep them both. This
             # prefiltering step should make the below sort less horrible, even

--- a/tests/source/code.js
+++ b/tests/source/code.js
@@ -48,6 +48,18 @@ class ContainingClass {
     }
 
     /**
+     * Another.
+     */
+    anotherMethod() {
+    }
+
+    /**
+     * More.
+     */
+    yetAnotherMethod() {
+    }
+
+    /**
      * Private thing.
      * @private
      */

--- a/tests/source/docs/autoclass_members_list_star.rst
+++ b/tests/source/docs/autoclass_members_list_star.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ContainingClass
+   :members: bar, *, someMethod

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -87,7 +87,7 @@ class Tests(TestCase):
         """
         self._file_contents_eq(
             'autoclass_members',
-            u'class ContainingClass(ho)\n\n   Class doc.\n\n   Constructor doc.\n\n   Arguments:\n      * **ho** – A thing\n\n   ContainingClass.bar\n\n      Setting this also frobs the frobnicator.\n\n   ContainingClass.someMethod(hi)\n\n      Here.\n\n   ContainingClass.someVar\n\n      A var\n')
+            u'class ContainingClass(ho)\n\n   Class doc.\n\n   Constructor doc.\n\n   Arguments:\n      * **ho** – A thing\n\n   ContainingClass.anotherMethod()\n\n      Another.\n\n   ContainingClass.bar\n\n      Setting this also frobs the frobnicator.\n\n   ContainingClass.someMethod(hi)\n\n      Here.\n\n   ContainingClass.someVar\n\n      A var\n\n   ContainingClass.yetAnotherMethod()\n\n      More.\n')
 
     def test_autoclass_members_list(self):
         """Make sure including a list of names after ``members`` limits it to
@@ -95,6 +95,14 @@ class Tests(TestCase):
         self._file_contents_eq(
             'autoclass_members_list',
             'class ClosedClass()\n\n   Closed class.\n\n   ClosedClass.publical3()\n\n      Public thing 3.\n\n   ClosedClass.publical()\n\n      Public thing.\n')
+
+    def test_autoclass_members_list_star(self):
+        """Make sure including ``*`` in a list of names after
+        ``members`` includes the rest of the names in the normal order
+        at that point."""
+        self._file_contents_eq(
+            'autoclass_members_list_star',
+            u'class ContainingClass(ho)\n\n   Class doc.\n\n   Constructor doc.\n\n   Arguments:\n      * **ho** – A thing\n\n   ContainingClass.bar\n\n      Setting this also frobs the frobnicator.\n\n   ContainingClass.anotherMethod()\n\n      Another.\n\n   ContainingClass.someVar\n\n      A var\n\n   ContainingClass.yetAnotherMethod()\n\n      More.\n\n   ContainingClass.someMethod(hi)\n\n      Here.\n')
 
     def test_autoclass_alphabetical(self):
         """Make sure members sort alphabetically when not otherwise specified."""


### PR DESCRIPTION
This should allow me to control the ordering like I want in mozilla/pioneer-studies-addon-utils#4.