### PR TITLE
Render JSDoc @example tag.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,7 @@ Caveats
 =======
 
 * We don't understand the inline JSDoc constructs like ``{@link foo}``; you have to use Sphinx-style equivalents for now, like ``:js:func:`foo``` (or simply ``:func:`foo``` if you have set ``primary_domain = 'js'`` in conf.py.
-* So far, we understand and convert only the JSDoc block tags ``@param``, ``@returns``, ``@throws``, and their synonyms. Other ones will go *poof* into the ether.
+* So far, we understand and convert only the JSDoc block tags ``@param``, ``@returns``, ``@throws``, ``@example`` (without the optional ``<caption>``), and their synonyms. Other ones will go *poof* into the ether.
 
 Tests
 =====

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -137,6 +137,7 @@ class AutoFunctionRenderer(JsRenderer):
             params=self._formal_params(doclet),
             fields=self._fields(doclet),
             description=doclet.get('description', ''),
+            examples=doclet.get('examples', ''),
             content='\n'.join(self._content))
 
 
@@ -148,6 +149,7 @@ class AutoClassRenderer(JsRenderer):
             name=name,
             params=self._formal_params(doclet),
             fields=self._fields(doclet),
+            examples=doclet.get('examples', ''),
             class_comment=doclet.get('classdesc', ''),
             constructor_comment=doclet.get('description', ''),
             content='\n'.join(self._content),
@@ -227,6 +229,7 @@ class AutoAttributeRenderer(JsRenderer):
         return dict(
             name=name,
             description=doclet.get('description', ''),
+            examples=doclet.get('examples', ''),
             content='\n'.join(self._content))
 
 

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -6,4 +6,11 @@
 
    {{ content|indent(3) }}
 
+   {% if examples -%}
+   :Examples:
+   {% for example in examples -%}
+     .. code-block:: js
 
+     {{ example|indent(5) }}
+   {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -6,10 +6,11 @@
 
    {% if examples -%}
    :Examples:
-   {% for example in examples -%}
-     .. code-block:: js
 
-     {{ example|indent(5) }}
+   {% for example in examples -%}
+   .. code-block:: js
+
+      {{ example|indent(6) }}
    {% endfor %}
    {%- endif %}
 

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -4,8 +4,6 @@
      {{ description|indent(3) }}
    {%- endif %}
 
-   {{ content|indent(3) }}
-
    {% if examples -%}
    :Examples:
    {% for example in examples -%}
@@ -14,3 +12,5 @@
      {{ example|indent(5) }}
    {% endfor %}
    {%- endif %}
+
+   {{ content|indent(3) }}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -12,12 +12,6 @@
      :{{ heads|join(' ') }}: {{ tail }}
    {% endfor %}
 
-   {{ content|indent(3) }}
-
-   {% if members -%}
-     {{ members|indent(3) }}
-   {%- endif %}
-
    {% if examples -%}
    :Examples:
    {% for example in examples -%}
@@ -25,4 +19,10 @@
 
      {{ example|indent(5) }}
    {% endfor %}
+   {%- endif %}
+
+   {{ content|indent(3) }}
+
+   {% if members -%}
+     {{ members|indent(3) }}
    {%- endif %}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -18,4 +18,11 @@
      {{ members|indent(3) }}
    {%- endif %}
 
+   {% if examples -%}
+   :Examples:
+   {% for example in examples -%}
+     .. code-block:: js
 
+     {{ example|indent(5) }}
+   {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -14,10 +14,11 @@
 
    {% if examples -%}
    :Examples:
-   {% for example in examples -%}
-     .. code-block:: js
 
-     {{ example|indent(5) }}
+   {% for example in examples -%}
+   .. code-block:: js
+
+      {{ example|indent(6) }}
    {% endfor %}
    {%- endif %}
 

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -10,10 +10,12 @@
 
    {% if examples -%}
    :Examples:
-   {% for example in examples -%}
-     .. code-block:: js
 
-     {{ example|indent(5) }}
+   {% for example in examples -%}
+   .. code-block:: js
+
+      {{ example|indent(6) }}
+
    {% endfor %}
    {%- endif %}
 

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -10,4 +10,11 @@
 
    {{ content|indent(3) }}
 
+   {% if examples -%}
+   :Examples:
+   {% for example in examples -%}
+     .. code-block:: js
 
+     {{ example|indent(5) }}
+   {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -8,8 +8,6 @@
      :{{ heads|join(' ') }}: {{ tail }}
    {% endfor %}
 
-   {{ content|indent(3) }}
-
    {% if examples -%}
    :Examples:
    {% for example in examples -%}
@@ -18,3 +16,5 @@
      {{ example|indent(5) }}
    {% endfor %}
    {%- endif %}
+
+   {{ content|indent(3) }}

--- a/tests/source/code.js
+++ b/tests/source/code.js
@@ -114,3 +114,30 @@ function shadow() {}
  * @callback requestCallback
  * @param {number} responseCode
  */
+
+/**
+ * JSDoc example tag
+ *
+ * @example
+ * // This is the example.
+ * exampleTag();
+ */
+function exampleTag() {}
+
+/**
+ * JSDoc example tag for class
+ *
+ * @example
+ * // This is the example.
+ * new ExampleClass();
+ */
+class ExampleClass {}
+
+/**
+ * JSDoc example tag for attribute
+ *
+ * @example
+ * // This is the example.
+ * console.log(ExampleAttribute);
+ */
+const ExampleAttribute = null;

--- a/tests/source/docs/autoattribute_example.rst
+++ b/tests/source/docs/autoattribute_example.rst
@@ -1,0 +1,1 @@
+.. js:autoattribute:: ExampleAttribute

--- a/tests/source/docs/autoclass_example.rst
+++ b/tests/source/docs/autoclass_example.rst
@@ -1,0 +1,1 @@
+.. js:autoclass:: ExampleClass

--- a/tests/source/docs/autofunction_example.rst
+++ b/tests/source/docs/autofunction_example.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: exampleTag

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,6 +70,16 @@ class Tests(TestCase):
             'autofunction_callback',
             u'requestCallback()\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) –\n')
 
+    def test_autofunction_example(self):
+        """Make sure @example tags can be documented with autofunction."""
+        self._file_contents_eq(
+            'autofunction_example',
+            u'exampleTag()\n\n'
+            '   JSDoc example tag\n\n'
+            '   Examples:\n'
+            '      // This is the example.\n'
+            '      exampleTag();\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""
@@ -124,11 +134,31 @@ class Tests(TestCase):
         assert_not_in('publical2', contents)
         assert_not_in('publical3', contents)
 
+    def test_autoclass_example(self):
+        """Make sure @example tags can be documented with autoclass."""
+        self._file_contents_eq(
+            'autoclass_example',
+            u'class ExampleClass()\n\n'
+            '   JSDoc example tag for class\n\n'
+            '   Examples:\n'
+            '      // This is the example.\n'
+            '      new ExampleClass();\n')
+
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
         self._file_contents_eq(
             'autoattribute',
             'ContainingClass.someVar\n\n   A var\n')
+
+    def test_autoattribute_example(self):
+        """Make sure @example tags can be documented with autoattribute."""
+        self._file_contents_eq(
+            'autoattribute_example',
+            u'ExampleAttribute\n\n'
+            '   JSDoc example tag for attribute\n\n'
+            '   Examples:\n'
+            '      // This is the example.\n'
+            '      console.log(ExampleAttribute);\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""


### PR DESCRIPTION
This does not render the optional caption. Let me know if you'd like to switch around the formatting; right now, all example sections are at the end.

Fixes #41.

Example:
![screenshot 2018-03-08 at 12 36 46](https://user-images.githubusercontent.com/327919/37166569-651520fe-22cd-11e8-909a-6595e13d65bf.png)
