### PR TITLE
Fix line wrapping on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 /.tox
 /dist
 /tests/source/docs/_build
-/build
-*/__pycache__/*
-/.vscode
 sphinx_js.egg-info/
+# Python 3
+*/__pycache__/*
+# Python 2.7
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist
 /tests/source/docs/_build
 /build
+*/__pycache__/*
+/.vscode
+sphinx_js.egg-info/

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -124,7 +124,7 @@ class JsRenderer(object):
         for field_name, callback in iteritems(FIELD_TYPES):
             for field in doclet.get(field_name, []):
                 description = field.get('description', '')
-                unwrapped = sub(r'[ \t]*\n[ \t]*', ' ', description)
+                unwrapped = sub(r'[ \t]*[\r\n]+[ \t]*', ' ', description)
                 yield callback(field, unwrapped)
 
 


### PR DESCRIPTION
Windows newline includes a LF(\r). This needs to be taken into
account when removing the wrapping.