### PR TITLE
Separate param type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist
 /tests/source/docs/_build
 /build
+*/__pycache__/*
+/.vscode
+sphinx_js.egg-info/

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -117,11 +117,13 @@ class JsRenderer(object):
         tail comes after.
 
         """
-        FIELD_TYPES = OrderedDict([('params', _params_formatter),
+        FIELD_TYPES = [('params', _params_formatter),
+                       ('params', _param_type_formatter),
                                    ('properties', _params_formatter),
+                       ('properties', _param_type_formatter),
                                    ('exceptions', _exceptions_formatter),
-                                   ('returns', _returns_formatter)])
-        for field_name, callback in iteritems(FIELD_TYPES):
+                       ('returns', _returns_formatter)]
+        for field_name, callback in FIELD_TYPES:
             for field in doclet.get(field_name, []):
                 description = field.get('description', '')
                 unwrapped = sub(r'[ \t]*[\r\n]+[ \t]*', ' ', description)
@@ -240,14 +242,15 @@ def _returns_formatter(field, description):
 
 def _params_formatter(field, description):
     """Derive heads and tail from ``@param`` blocks."""
-    heads = ['param']
-    types = _or_types(field)
-    if types:
-        heads.append(types)
-    heads.append(field['name'])
+    heads = ['param', field['name']]
     tail = description
     return heads, tail
 
+def _param_type_formatter(field, description):
+    """Derive heads and tail from ``@param`` blocks."""
+    heads = ['type', field['name']]
+    tail = _or_types(field)
+    return heads, tail
 
 def _exceptions_formatter(field, description):
     """Derive heads and tail from ``@throws`` blocks."""

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -124,7 +124,7 @@ class JsRenderer(object):
         for field_name, callback in iteritems(FIELD_TYPES):
             for field in doclet.get(field_name, []):
                 description = field.get('description', '')
-                unwrapped = sub(r'[ \t]*\n[ \t]*', ' ', description)
+                unwrapped = sub(r'[ \t]*[\r\n]+[ \t]*', ' ', description)
                 yield callback(field, unwrapped)
 
 


### PR DESCRIPTION
I split ':param type name: description' into ':param name: description' followed by ':type name: type'.
This allows the type to be more complex, for example including spaces, which is required for typescript types.