### PR TITLE
Display params default values

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from re import sub
-from functools import reduce
 
 from docutils.parsers.rst import Parser as RstParser
 from docutils.statemachine import StringList
@@ -117,10 +116,13 @@ class JsRenderer(object):
         # explicit formal param. Even look at params that are really
         # documenting subproperties of formal params. Also handles params
         # default values.
-        params = ["%s=%s" % (param, value) if value else param for param, value in reduce(
-            lambda params, param: params + [param] if not param[0] in [i[0] for i in params] else params,
-            [(param['name'].split(".")[0], param.get('defaultvalue')) for param in doclet.get('params', [])],
-            [])]
+        params = []
+        used_names = []
+
+        for name, default in [(param['name'].split(".")[0], param.get('defaultvalue')) for param in doclet.get('params', [])]:
+            if name not in used_names:
+                params.append("%s=%s" % (name, default) if default is not None else name)
+                used_names.append(name)
 
         # Use params from JS code if there are no documented params:
         if not params:

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -115,11 +115,12 @@ class JsRenderer(object):
 
         # Harvest params from the @param tag unless they collide with an
         # explicit formal param. Even look at params that are really
-        # documenting subproperties of formal params.
-        params = reduce(
-            lambda l, v: l + [v] if not v in l else l,
-            [param['name'].split('.')[0] for param in doclet.get('params', [])],
-            [])
+        # documenting subproperties of formal params. Also handles params
+        # default values.
+        params = ["%s=%s" % (param, value) if value else param for param, value in reduce(
+            lambda params, param: params + [param] if not param[0] in [i[0] for i in params] else params,
+            [(param['name'].split(".")[0], param.get('defaultvalue')) for param in doclet.get('params', [])],
+            [])]
 
         # Use params from JS code if there are no documented params:
         if not params:

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -155,3 +155,15 @@ function destructuredParams(p1, {foo, bar}) {}
  * @param {string} [p2="foobar"]
  */
 function defaultValues(p1=42, p2="foobar") {}
+
+/**
+ * @param {number} [p1=42]
+ * @param {string} [p2="foobar"]
+ */
+function defaultValuesOnlyInDoc(p1, p2) {}
+
+/**
+ * @param {number} p1
+ * @param {string} p2
+ */
+function defaultValuesOnlyInJs(p1=42, p2="foobar") {}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -149,3 +149,9 @@ const ExampleAttribute = null;
  * @param {String} p2.bar
  */
 function destructuredParams(p1, {foo, bar}) {}
+
+/**
+ * @param {number} [p1=42]
+ * @param {string} [p2="foobar"]
+ */
+function defaultValues(p1=42, p2="foobar") {}

--- a/tests/test_build/source/docs/autofunction_default_values.rst
+++ b/tests/test_build/source/docs/autofunction_default_values.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: defaultValues

--- a/tests/test_build/source/docs/autofunction_default_values_only_in_doc.rst
+++ b/tests/test_build/source/docs/autofunction_default_values_only_in_doc.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: defaultValuesOnlyInDoc

--- a/tests/test_build/source/docs/autofunction_default_values_only_in_js.rst
+++ b/tests/test_build/source/docs/autofunction_default_values_only_in_js.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: defaultValuesOnlyInJs

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -73,10 +73,30 @@ class Tests(SphinxBuildTestCase):
             '      * **p2.bar** (*String*) --\n')
 
     def test_autofunction_defaut_values(self):
-        "Make sure params default values appear in the function definition."""
+        """Make sure params default values appear in the function definition."""
         self._file_contents_eq(
             'autofunction_default_values',
             u'defaultValues(p1=42, p2="foobar")\n\n'
+            '   Arguments:\n'
+            '      * **p1** (*number*) --\n\n'
+            '      * **p2** (*string*) --\n')
+
+    def test_autofunction_defaut_values_only_in_doc(self):
+        """Make sure params default values appear in the function definition when
+        the default values only appears in JSdoc comment."""
+        self._file_contents_eq(
+            'autofunction_default_values_only_in_doc',
+            u'defaultValuesOnlyInDoc(p1=42, p2="foobar")\n\n'
+            '   Arguments:\n'
+            '      * **p1** (*number*) --\n\n'
+            '      * **p2** (*string*) --\n')
+
+    def test_autofunction_defaut_values_only_in_js(self):
+        """Make sure params default values appear in the function definition when
+        the default values only appears in Javascript Code (ES2015)."""
+        self._file_contents_eq(
+            'autofunction_default_values_only_in_js',
+            u'defaultValuesOnlyInJs(p1=42, p2=foobar)\n\n'
             '   Arguments:\n'
             '      * **p1** (*number*) --\n\n'
             '      * **p2** (*string*) --\n')

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -61,7 +61,7 @@ class Tests(SphinxBuildTestCase):
             '      exampleTag();\n')
 
     def test_autofunction_destructured_params(self):
-        """Make shure that all documented params appears in the function
+        """Make sure that all documented params appears in the function
         definition."""
         self._file_contents_eq(
             'autofunction_destructured_params',
@@ -73,7 +73,7 @@ class Tests(SphinxBuildTestCase):
             '      * **p2.bar** (*String*) --\n')
 
     def test_autofunction_defaut_values(self):
-        "Make shure params default values appear in the function definition."""
+        "Make sure params default values appear in the function definition."""
         self._file_contents_eq(
             'autofunction_default_values',
             u'defaultValues(p1=42, p2="foobar")\n\n'

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -72,6 +72,15 @@ class Tests(SphinxBuildTestCase):
             '      * **p2.foo** (*String*) --\n\n'
             '      * **p2.bar** (*String*) --\n')
 
+    def test_autofunction_defaut_values(self):
+        "Make shure params default values appear in the function definition."""
+        self._file_contents_eq(
+            'autofunction_default_values',
+            u'defaultValues(p1=42, p2="foobar")\n\n'
+            '   Arguments:\n'
+            '      * **p1** (*number*) --\n\n'
+            '      * **p2** (*string*) --\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""


### PR DESCRIPTION
Hello,

This PR displays the default value of parameters in the generated doc:
```javascript
/**
 * Lorem ipsum dolor...
 * 
 * @param {String} [name="foobar"]
 */
function example(name="foobar") {
   // ...
}
```

![capture d ecran de 2018-03-23 16-09-44](https://user-images.githubusercontent.com/971438/37837418-6526630c-2eb5-11e8-8e3b-5c3a5d8f2133.png)

Resolve #50 