### PR TITLE
Types of extracted default args are unambiguous in doclets after all. Get them right in extracted formal param lists. Fix #56.

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from json import dumps
 from re import sub
 
 from docutils.parsers.rst import Parser as RstParser
@@ -118,11 +119,12 @@ class JsRenderer(object):
         # default values.
         params = []
         used_names = []
+        MARKER = object()
 
-        for name, default in [(param['name'].split('.')[0], param.get('defaultvalue'))
+        for name, default in [(param['name'].split('.')[0], param.get('defaultvalue', MARKER))
                               for param in doclet.get('params', [])]:
             if name not in used_names:
-                params.append('%s=%s' % (name, default) if default is not None else name)
+                params.append('%s=%s' % (name, dumps(default)) if default is not MARKER else name)
                 used_names.append(name)
 
         # Use params from JS code if there are no documented params:

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -151,8 +151,10 @@ const ExampleAttribute = null;
 function destructuredParams(p1, {foo, bar}) {}
 
 /**
- * @param {number} [p1=42]
- * @param {string} [p2]
- * @param {string} [p3="true"]
+ * @param [a=42]
+ * @param [b=a string]
+ * @param [c]
+ * @param [d]
+ * @param [e]
  */
-function defaultValues(p1, p2="foobar", p3="true") {}
+function defaultValues(a, b, c="true", d=true, e=null) {}

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -74,24 +74,16 @@ class Tests(SphinxBuildTestCase):
 
     def test_autofunction_default_values(self):
         """Make sure params default values appear in the function definition,
-        whether the defaults are defined in JSDoc or JS.
-
-        Unfortunately, there is no way to disambiguate strings from symbolic
-        values used as default args in JS code: for instance, ``true`` vs.
-        ``"true"``. JSDoc's doclets render them both without quotes. However,
-        you can work around this by specifying your defaults in the JSDoc
-        comment rather than the JS code, as we do with p3. It would be lovely
-        if JSDoc changed its behavior someday so we could know to put quotes
-        around "foobar" as well.
-
-        """
+        whether the defaults are defined in JSDoc or JS."""
         self._file_contents_eq(
             'autofunction_default_values',
-            u'defaultValues(p1=42, p2=foobar, p3="true")\n\n'
+            'defaultValues(a=42, b="a string", c="true", d=true, e=null)\n\n'
             '   Arguments:\n'
-            '      * **p1** (*number*) --\n\n'
-            '      * **p2** (*string*) --\n\n'
-            '      * **p3** (*string*) --\n')
+            '      * **a** --\n\n'
+            '      * **b** --\n\n'
+            '      * **c** --\n\n'
+            '      * **d** --\n\n'
+            '      * **e** --\n')
 
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor


### PR DESCRIPTION
JSDoc doesn't extract compound default literals like objects or Arrays yet, so we don't test those.

@flozz Would you mind reviewing this? Thank you!