### PR TITLE
Variadic parameters & @deprecated

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -222,6 +222,7 @@ class AutoFunctionRenderer(JsRenderer):
             fields=self._fields(doclet),
             description=doclet.get('description', ''),
             examples=doclet.get('examples', ''),
+            deprecated=doclet.get('deprecated', ''),
             content='\n'.join(self._content))
 
 
@@ -234,6 +235,7 @@ class AutoClassRenderer(JsRenderer):
             params=self._formal_params(doclet),
             fields=self._fields(doclet),
             examples=doclet.get('examples', ''),
+            deprecated=doclet.get('deprecated', ''),
             class_comment=doclet.get('classdesc', ''),
             constructor_comment=doclet.get('description', ''),
             content='\n'.join(self._content),
@@ -314,6 +316,7 @@ class AutoAttributeRenderer(JsRenderer):
         return dict(
             name=name,
             description=doclet.get('description', ''),
+            deprecated=doclet.get('deprecated', ''),
             examples=doclet.get('examples', ''),
             content='\n'.join(self._content))
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -223,7 +223,7 @@ class AutoFunctionRenderer(JsRenderer):
             description=doclet.get('description', ''),
             examples=doclet.get('examples', ''),
             deprecated=doclet.get('deprecated', ''),
-            seealso=doclet.get('see', []),
+            see_also=doclet.get('see', []),
             content='\n'.join(self._content))
 
 
@@ -237,7 +237,7 @@ class AutoClassRenderer(JsRenderer):
             fields=self._fields(doclet),
             examples=doclet.get('examples', ''),
             deprecated=doclet.get('deprecated', ''),
-            seealso=doclet.get('see', []),
+            see_also=doclet.get('see', []),
             class_comment=doclet.get('classdesc', ''),
             constructor_comment=doclet.get('description', ''),
             content='\n'.join(self._content),
@@ -319,7 +319,7 @@ class AutoAttributeRenderer(JsRenderer):
             name=name,
             description=doclet.get('description', ''),
             deprecated=doclet.get('deprecated', ''),
-            seealso=doclet.get('see', []),
+            see_also=doclet.get('see', []),
             examples=doclet.get('examples', ''),
             content='\n'.join(self._content))
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -171,10 +171,15 @@ class JsRenderer(object):
         used_names = []
         MARKER = object()
 
-        for name, default, type in [(param['name'].split('.')[0],
-                                     param.get('defaultvalue', MARKER),
-                                     param.get('type', {'names': []}))
-                                    for param in doclet.get('params', [])]:
+        for param in doclet.get('params', []):
+            name = param['name'].split('.')[0]
+            default = param.get('defaultvalue', MARKER)
+            type = param.get('type', {'names': []})
+
+            # Add '*' to the parameter name if it's a variadic argument
+            if param.get('variable'):
+                name = '*' + name
+
             if name not in used_names:
                 params.append(rst.escape(name) if default is MARKER else
                               '%s=%s' % (rst.escape(name),

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -176,9 +176,9 @@ class JsRenderer(object):
             default = param.get('defaultvalue', MARKER)
             type = param.get('type', {'names': []})
 
-            # Add '*' to the parameter name if it's a variadic argument
+            # Add '...' to the parameter name if it's a variadic argument
             if param.get('variable'):
-                name = '*' + name
+                name = '...' + name
 
             if name not in used_names:
                 params.append(rst.escape(name) if default is MARKER else

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -223,6 +223,7 @@ class AutoFunctionRenderer(JsRenderer):
             description=doclet.get('description', ''),
             examples=doclet.get('examples', ''),
             deprecated=doclet.get('deprecated', ''),
+            seealso=doclet.get('see', []),
             content='\n'.join(self._content))
 
 
@@ -236,6 +237,7 @@ class AutoClassRenderer(JsRenderer):
             fields=self._fields(doclet),
             examples=doclet.get('examples', ''),
             deprecated=doclet.get('deprecated', ''),
+            seealso=doclet.get('see', []),
             class_comment=doclet.get('classdesc', ''),
             constructor_comment=doclet.get('description', ''),
             content='\n'.join(self._content),
@@ -317,6 +319,7 @@ class AutoAttributeRenderer(JsRenderer):
             name=name,
             description=doclet.get('description', ''),
             deprecated=doclet.get('deprecated', ''),
+            seealso=doclet.get('see', []),
             examples=doclet.get('examples', ''),
             content='\n'.join(self._content))
 

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -222,7 +222,7 @@ class AutoFunctionRenderer(JsRenderer):
             fields=self._fields(doclet),
             description=doclet.get('description', ''),
             examples=doclet.get('examples', ''),
-            deprecated=doclet.get('deprecated', ''),
+            deprecated=doclet.get('deprecated', False),
             see_also=doclet.get('see', []),
             content='\n'.join(self._content))
 
@@ -236,7 +236,7 @@ class AutoClassRenderer(JsRenderer):
             params=self._formal_params(doclet),
             fields=self._fields(doclet),
             examples=doclet.get('examples', ''),
-            deprecated=doclet.get('deprecated', ''),
+            deprecated=doclet.get('deprecated', False),
             see_also=doclet.get('see', []),
             class_comment=doclet.get('classdesc', ''),
             constructor_comment=doclet.get('description', ''),
@@ -318,7 +318,7 @@ class AutoAttributeRenderer(JsRenderer):
         return dict(
             name=name,
             description=doclet.get('description', ''),
-            deprecated=doclet.get('deprecated', ''),
+            deprecated=doclet.get('deprecated', False),
             see_also=doclet.get('see', []),
             examples=doclet.get('examples', ''),
             content='\n'.join(self._content))

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -23,10 +23,10 @@
 
    {{ content|indent(3) }}
 
-   {% if seealso -%}
+   {% if see_also -%}
    .. seealso::
 
-      {% for reference in seealso -%}
+      {% for reference in see_also -%}
       - :any:`{{ reference }}`
       {% endfor %}
    {%- endif %}

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -22,3 +22,11 @@
    {%- endif %}
 
    {{ content|indent(3) }}
+
+   {% if seealso -%}
+   .. seealso::
+
+      {% for reference in seealso -%}
+      - :any:`{{ reference }}`
+      {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -1,32 +1,15 @@
+{% import 'common.rst' as common %}
+
 .. js:attribute:: {{ name }}
 
-   {% if deprecated -%}
-   .. note::
-
-      This attribute is deprecated.
-      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
-   {%- endif %}
+   {{ common.deprecated(deprecated)|indent(3) }}
 
    {% if description -%}
      {{ description|indent(3) }}
    {%- endif %}
 
-   {% if examples -%}
-   **Examples:**
-
-   {% for example in examples -%}
-   .. code-block:: js
-
-      {{ example|indent(6) }}
-   {% endfor %}
-   {%- endif %}
+   {{ common.examples(examples)|indent(3) }}
 
    {{ content|indent(3) }}
 
-   {% if see_also -%}
-   .. seealso::
-
-      {% for reference in see_also -%}
-      - :any:`{{ reference }}`
-      {% endfor %}
-   {%- endif %}
+   {{ common.see_also(see_also)|indent(3) }}

--- a/sphinx_js/templates/attribute.rst
+++ b/sphinx_js/templates/attribute.rst
@@ -1,5 +1,12 @@
 .. js:attribute:: {{ name }}
 
+   {% if deprecated -%}
+   .. note::
+
+      This attribute is deprecated.
+      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
+   {%- endif %}
+
    {% if description -%}
      {{ description|indent(3) }}
    {%- endif %}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -35,10 +35,10 @@
      {{ members|indent(3) }}
    {%- endif %}
 
-   {% if seealso -%}
+   {% if see_also -%}
    .. seealso::
 
-      {% for reference in seealso -%}
+      {% for reference in see_also -%}
       - :any:`{{ reference }}`
       {% endfor %}
    {%- endif %}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -1,11 +1,8 @@
+{% import 'common.rst' as common %}
+
 .. js:class:: {{ name }}{{ params }}
 
-   {% if deprecated -%}
-   .. note::
-
-      This class is deprecated.
-      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
-   {%- endif %}
+   {{ common.deprecated(deprecated)|indent(3) }}
 
    {% if class_comment -%}
      {{ class_comment|indent(3) }}
@@ -19,15 +16,7 @@
      :{{ heads|join(' ') }}: {{ tail }}
    {% endfor %}
 
-   {% if examples -%}
-   **Examples:**
-
-   {% for example in examples -%}
-   .. code-block:: js
-
-      {{ example|indent(6) }}
-   {% endfor %}
-   {%- endif %}
+   {{ common.examples(examples)|indent(3) }}
 
    {{ content|indent(3) }}
 
@@ -35,10 +24,4 @@
      {{ members|indent(3) }}
    {%- endif %}
 
-   {% if see_also -%}
-   .. seealso::
-
-      {% for reference in see_also -%}
-      - :any:`{{ reference }}`
-      {% endfor %}
-   {%- endif %}
+   {{ common.see_also(see_also)|indent(3) }}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -34,3 +34,11 @@
    {% if members -%}
      {{ members|indent(3) }}
    {%- endif %}
+
+   {% if seealso -%}
+   .. seealso::
+
+      {% for reference in seealso -%}
+      - :any:`{{ reference }}`
+      {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/class.rst
+++ b/sphinx_js/templates/class.rst
@@ -1,5 +1,12 @@
 .. js:class:: {{ name }}{{ params }}
 
+   {% if deprecated -%}
+   .. note::
+
+      This class is deprecated.
+      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
+   {%- endif %}
+
    {% if class_comment -%}
      {{ class_comment|indent(3) }}
    {%- endif %}

--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -11,11 +11,11 @@
 {% if items -%}
 **Examples:**
 
-{% for example in items -%}
-.. code-block:: js
+   {% for example in items -%}
+   .. code-block:: js
 
-   {{ example|indent(6) }}
-{% endfor %}
+      {{ example|indent(6) }}
+   {% endfor %}
 {%- endif %}
 {% endmacro %}
 

--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -11,11 +11,11 @@
 {% if items -%}
 **Examples:**
 
-   {% for example in items -%}
-   .. code-block:: js
+{% for example in items -%}
+.. code-block:: js
 
-      {{ example|indent(6) }}
-   {% endfor %}
+   {{ example|indent(3) }}
+{% endfor %}
 {%- endif %}
 {% endmacro %}
 

--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -1,0 +1,30 @@
+{% macro deprecated(message) %}
+{% if message -%}
+.. note::
+
+   Deprecated
+   {%- if message is string -%}: {{ message }}{% else %}.{% endif -%}
+{%- endif %}
+{% endmacro %}
+
+{% macro examples(items) %}
+{% if items -%}
+**Examples:**
+
+{% for example in items -%}
+.. code-block:: js
+
+   {{ example|indent(6) }}
+{% endfor %}
+{%- endif %}
+{% endmacro %}
+
+{% macro see_also(items) %}
+{% if items -%}
+.. seealso::
+
+   {% for reference in items -%}
+   - :any:`{{ reference }}`
+   {% endfor %}
+{%- endif %}
+{% endmacro %}

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -27,3 +27,11 @@
    {%- endif %}
 
    {{ content|indent(3) }}
+
+   {% if seealso -%}
+   .. seealso::
+
+      {% for reference in seealso -%}
+      - :any:`{{ reference }}`
+      {% endfor %}
+   {%- endif %}

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -1,11 +1,8 @@
+{% import 'common.rst' as common %}
+
 .. js:function:: {{ name }}{{ params }}
 
-   {% if deprecated -%}
-   .. note::
-
-      This function is deprecated.
-      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
-   {%- endif %}
+   {{ common.deprecated(deprecated)|indent(3) }}
 
    {% if description -%}
      {{ description|indent(3) }}
@@ -15,23 +12,8 @@
      :{{ heads|join(' ') }}: {{ tail }}
    {% endfor %}
 
-   {% if examples -%}
-   **Examples:**
-
-   {% for example in examples -%}
-   .. code-block:: js
-
-      {{ example|indent(6) }}
-
-   {% endfor %}
-   {%- endif %}
+   {{ common.examples(examples)|indent(3) }}
 
    {{ content|indent(3) }}
 
-   {% if see_also -%}
-   .. seealso::
-
-      {% for reference in see_also -%}
-      - :any:`{{ reference }}`
-      {% endfor %}
-   {%- endif %}
+   {{ common.see_also(see_also)|indent(3) }}

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -1,5 +1,12 @@
 .. js:function:: {{ name }}{{ params }}
 
+   {% if deprecated -%}
+   .. note::
+
+      This function is deprecated.
+      {% if deprecated is string -%}{{ deprecated }}{% endif -%}
+   {%- endif %}
+
    {% if description -%}
      {{ description|indent(3) }}
    {%- endif %}

--- a/sphinx_js/templates/function.rst
+++ b/sphinx_js/templates/function.rst
@@ -28,10 +28,10 @@
 
    {{ content|indent(3) }}
 
-   {% if seealso -%}
+   {% if see_also -%}
    .. seealso::
 
-      {% for reference in seealso -%}
+      {% for reference in see_also -%}
       - :any:`{{ reference }}`
       {% endfor %}
    {%- endif %}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -181,3 +181,18 @@ function defaultsDocumentedInCode(num=5, str="true", bool=true, nil=null) {}
  * @param args
  */
 function variadicParameter(a, ...args) {}
+
+/** @deprecated */
+function deprecatedFunction() {}
+/** @deprecated don't use anymore */
+function deprecatedExplanatoryFunction() {}
+
+/** @deprecated */
+const DeprecatedAttribute = null;
+/** @deprecated don't use anymore */
+const DeprecatedExplanatoryAttribute = null;
+
+/** @deprecated */
+class DeprecatedClass {}
+/** @deprecated don't use anymore */
+class DeprecatedExplanatoryClass {}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -174,3 +174,10 @@ function defaultsDocumentedInDoclet(func, strNum, strBool, num, nil) {}
  * @param [nil]
  */
 function defaultsDocumentedInCode(num=5, str="true", bool=true, nil=null) {}
+
+/**
+ * Variadic parameter
+ * @param a
+ * @param args
+ */
+function variadicParameter(a, ...args) {}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -196,3 +196,22 @@ const DeprecatedExplanatoryAttribute = null;
 class DeprecatedClass {}
 /** @deprecated don't use anymore */
 class DeprecatedExplanatoryClass {}
+
+/**
+ * @see DeprecatedClass
+ * @see deprecatedFunction
+ * @see DeprecatedAttribute
+ */
+function seeFunction() {}
+/**
+ * @see DeprecatedClass
+ * @see deprecatedFunction
+ * @see DeprecatedAttribute
+ */
+const SeeAttribute = null;
+/**
+ * @see DeprecatedClass
+ * @see deprecatedFunction
+ * @see DeprecatedAttribute
+ */
+class SeeClass {}

--- a/tests/test_build/source/docs/autoattribute_deprecated.rst
+++ b/tests/test_build/source/docs/autoattribute_deprecated.rst
@@ -1,0 +1,3 @@
+.. js:autoattribute:: DeprecatedAttribute
+
+.. js:autoattribute:: DeprecatedExplanatoryAttribute

--- a/tests/test_build/source/docs/autoattribute_see.rst
+++ b/tests/test_build/source/docs/autoattribute_see.rst
@@ -1,0 +1,1 @@
+.. js:autoattribute:: SeeAttribute

--- a/tests/test_build/source/docs/autoclass_deprecated.rst
+++ b/tests/test_build/source/docs/autoclass_deprecated.rst
@@ -1,0 +1,3 @@
+.. js:autoclass:: DeprecatedClass
+
+.. js:autoclass:: DeprecatedExplanatoryClass

--- a/tests/test_build/source/docs/autoclass_see.rst
+++ b/tests/test_build/source/docs/autoclass_see.rst
@@ -1,0 +1,1 @@
+.. js:autoclass:: SeeClass

--- a/tests/test_build/source/docs/autofunction_deprecated.rst
+++ b/tests/test_build/source/docs/autofunction_deprecated.rst
@@ -1,0 +1,3 @@
+.. js:autofunction:: deprecatedFunction
+
+.. js:autofunction:: deprecatedExplanatoryFunction

--- a/tests/test_build/source/docs/autofunction_see.rst
+++ b/tests/test_build/source/docs/autofunction_see.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: seeFunction

--- a/tests/test_build/source/docs/autofunction_variadic.rst
+++ b/tests/test_build/source/docs/autofunction_variadic.rst
@@ -1,0 +1,1 @@
+.. js:autofunction:: variadicParameter

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -108,6 +108,15 @@ class Tests(SphinxBuildTestCase):
             '      * **a** --\n\n'
             '      * **args** --\n')
 
+    def test_autofunction_deprecated(self):
+        """Make sure @deprecated tags can be documented with autofunction."""
+        self._file_contents_eq(
+            'autofunction_deprecated',
+            u'deprecatedFunction()\n\n'
+            '   Note: Deprecated.\n\n'
+            'deprecatedExplanatoryFunction()\n\n'
+            '   Note: Deprecated: don\'t use anymore\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""
@@ -172,6 +181,15 @@ class Tests(SphinxBuildTestCase):
             '      // This is the example.\n'
             '      new ExampleClass();\n')
 
+    def test_autoclass_deprecated(self):
+        """Make sure @deprecated tags can be documented with autoclass."""
+        self._file_contents_eq(
+            'autoclass_deprecated',
+            u'class DeprecatedClass()\n\n'
+            '   Note: Deprecated.\n\n'
+            'class DeprecatedExplanatoryClass()\n\n'
+            '   Note: Deprecated: don\'t use anymore\n')
+
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
         self._file_contents_eq(
@@ -187,6 +205,15 @@ class Tests(SphinxBuildTestCase):
             '   **Examples:**\n\n'
             '      // This is the example.\n'
             '      console.log(ExampleAttribute);\n')
+
+    def test_autoattribute_deprecated(self):
+        """Make sure @deprecated tags can be documented with autoattribute."""
+        self._file_contents_eq(
+            'autoattribute_deprecated',
+            u'DeprecatedAttribute\n\n'
+            '   Note: Deprecated.\n\n'
+            'DeprecatedExplanatoryAttribute\n\n'
+            '   Note: Deprecated: don\'t use anymore\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -54,7 +54,7 @@ class Tests(SphinxBuildTestCase):
         """Make sure @example tags can be documented with autofunction."""
         self._file_contents_eq(
             'autofunction_example',
-            u'exampleTag()\n\n'
+            'exampleTag()\n\n'
             '   JSDoc example tag\n\n'
             '   **Examples:**\n\n'
             '      // This is the example.\n'
@@ -112,10 +112,10 @@ class Tests(SphinxBuildTestCase):
         """Make sure @deprecated tags can be documented with autofunction."""
         self._file_contents_eq(
             'autofunction_deprecated',
-            u'deprecatedFunction()\n\n'
+            'deprecatedFunction()\n\n'
             '   Note: Deprecated.\n\n'
             'deprecatedExplanatoryFunction()\n\n'
-            '   Note: Deprecated: don\'t use anymore\n')
+            "   Note: Deprecated: don't use anymore\n")
 
     def test_autofunction_see(self):
         """Make sure @see tags work with autofunction."""
@@ -185,7 +185,7 @@ class Tests(SphinxBuildTestCase):
         """Make sure @example tags can be documented with autoclass."""
         self._file_contents_eq(
             'autoclass_example',
-            u'class ExampleClass()\n\n'
+            'class ExampleClass()\n\n'
             '   JSDoc example tag for class\n\n'
             '   **Examples:**\n\n'
             '      // This is the example.\n'
@@ -195,10 +195,10 @@ class Tests(SphinxBuildTestCase):
         """Make sure @deprecated tags can be documented with autoclass."""
         self._file_contents_eq(
             'autoclass_deprecated',
-            u'class DeprecatedClass()\n\n'
+            'class DeprecatedClass()\n\n'
             '   Note: Deprecated.\n\n'
             'class DeprecatedExplanatoryClass()\n\n'
-            '   Note: Deprecated: don\'t use anymore\n')
+            "   Note: Deprecated: don't use anymore\n")
 
     def test_autoclass_see(self):
         """Make sure @see tags work with autoclass."""
@@ -220,7 +220,7 @@ class Tests(SphinxBuildTestCase):
         """Make sure @example tags can be documented with autoattribute."""
         self._file_contents_eq(
             'autoattribute_example',
-            u'ExampleAttribute\n\n'
+            'ExampleAttribute\n\n'
             '   JSDoc example tag for attribute\n\n'
             '   **Examples:**\n\n'
             '      // This is the example.\n'
@@ -230,10 +230,10 @@ class Tests(SphinxBuildTestCase):
         """Make sure @deprecated tags can be documented with autoattribute."""
         self._file_contents_eq(
             'autoattribute_deprecated',
-            u'DeprecatedAttribute\n\n'
+            'DeprecatedAttribute\n\n'
             '   Note: Deprecated.\n\n'
             'DeprecatedExplanatoryAttribute\n\n'
-            '   Note: Deprecated: don\'t use anymore\n')
+            "   Note: Deprecated: don't use anymore\n")
 
     def test_autoattribute_see(self):
         """Make sure @see tags work with autoattribute."""

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -98,6 +98,16 @@ class Tests(SphinxBuildTestCase):
             '      * **bool** --\n\n'
             '      * **nil** --\n')
 
+    def test_autofunction_variadic(self):
+        """Make sure variadic parameters are rendered as ellipses."""
+        self._file_contents_eq(
+            'autofunction_variadic',
+            'variadicParameter(a, ...args)\n\n'
+            '   Variadic parameter\n\n'
+            '   Arguments:\n'
+            '      * **a** --\n\n'
+            '      * **args** --\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -117,6 +117,16 @@ class Tests(SphinxBuildTestCase):
             'deprecatedExplanatoryFunction()\n\n'
             '   Note: Deprecated: don\'t use anymore\n')
 
+    def test_autofunction_see(self):
+        """Make sure @see tags work with autofunction."""
+        self._file_contents_eq(
+            'autofunction_see',
+            'seeFunction()\n\n'
+            '   See also:\n\n'
+            '     * "DeprecatedClass"\n\n'
+            '     * "deprecatedFunction"\n\n'
+            '     * "DeprecatedAttribute"\n')
+
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
         comment."""
@@ -190,6 +200,16 @@ class Tests(SphinxBuildTestCase):
             'class DeprecatedExplanatoryClass()\n\n'
             '   Note: Deprecated: don\'t use anymore\n')
 
+    def test_autoclass_see(self):
+        """Make sure @see tags work with autoclass."""
+        self._file_contents_eq(
+            'autoclass_see',
+            'class SeeClass()\n\n'
+            '   See also:\n\n'
+            '     * "DeprecatedClass"\n\n'
+            '     * "deprecatedFunction"\n\n'
+            '     * "DeprecatedAttribute"\n')
+
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
         self._file_contents_eq(
@@ -214,6 +234,16 @@ class Tests(SphinxBuildTestCase):
             '   Note: Deprecated.\n\n'
             'DeprecatedExplanatoryAttribute\n\n'
             '   Note: Deprecated: don\'t use anymore\n')
+
+    def test_autoattribute_see(self):
+        """Make sure @see tags work with autoattribute."""
+        self._file_contents_eq(
+            'autoattribute_see',
+            'SeeAttribute\n\n'
+            '   See also:\n\n'
+            '     * "DeprecatedClass"\n\n'
+            '     * "deprecatedFunction"\n\n'
+            '     * "DeprecatedAttribute"\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""


### PR DESCRIPTION
Adds support for `@deprecated` and variadic parameters. Once these look good, I can add the test cases.

I rendered variadics as a Python star-arg, but on second thought, it'd probably make more sense to change it to an ellipsis.

![image](https://user-images.githubusercontent.com/327919/40280455-86b72d00-5c21-11e8-85e6-ac03c584c831.png)

Corresponding JSDoc:

```js
/**
 * Given projection IDs, returns a function that always returns those
 * IDs.
 *
 * Useful as the ``childrenFunc`` argument to a view when your
 * children are static.
 *
 * @param {...*} projections - The view IDs. (This is a variadic
 * function.)
 *
 * @alias gfx.constant
 */
```

I've rendered `@deprecated` as a `note` instead of `deprecated`, since the latter expects a version and possibly descriptive text, while JSDoc only gives you a chance to put descriptive text. I'm open to other suggestions on how to render this.

![image](https://user-images.githubusercontent.com/327919/40280441-5415f35e-5c21-11e8-8ad3-2d226accf505.png)

Corresponding JSDoc:

```js
    /**
     * @deprecated Use :func:`allocate` instead.
     */
```